### PR TITLE
Compilation fix related to vcpu unused variable

### DIFF
--- a/vmm/vcpu_factory_hook.cpp
+++ b/vmm/vcpu_factory_hook.cpp
@@ -161,6 +161,7 @@ public:
     vmcall_handler_hook(
         gsl::not_null<vcpu_t *> vcpu)
     {
+        bfignored(vcpu);
         // Store the guest virtual address of both the hello_world() function
         // and the hooked_hello_world() function
         //


### PR DESCRIPTION
Little fix for: 
` vcpu_factory_hook.cpp:162:33: error: unused parameter 'vcpu' [-Werror,-Wunused-parameter] `
              